### PR TITLE
Fix infinite redirect loop when prompt=login forces re-authentication

### DIFF
--- a/pages/api/auth/facebook/callback.js
+++ b/pages/api/auth/facebook/callback.js
@@ -157,11 +157,18 @@ export default async function handler(req, res) {
           params.set('code_challenge_method', decoded.code_challenge_method || 'S256')
         }
         
-        // Add prompt parameter if present
-        if (decoded.prompt) {
+        // WHAT: Never forward prompt=login back into this retry call.
+        // WHY: authorize.js treats prompt=login as "always show the login
+        //     form," unconditionally, before it even checks whether the
+        //     user is now authenticated -- forwarding it here after a
+        //     successful Facebook login sends the user straight back to the
+        //     login form again, forever. Re-authentication just happened;
+        //     that job is done. Other prompt values (consent, select_account)
+        //     still have meaning post-login and are preserved.
+        if (decoded.prompt && decoded.prompt !== 'login') {
           params.set('prompt', decoded.prompt)
         }
-        
+
         const authUrl = `/api/oauth/authorize?${params.toString()}`
         return res.redirect(302, authUrl)
       } catch (err) {

--- a/pages/api/auth/google/callback.js
+++ b/pages/api/auth/google/callback.js
@@ -228,8 +228,15 @@ export default async function handler(req, res) {
           params.set('code_challenge_method', decoded.code_challenge_method || 'S256')
         }
 
-        // Add prompt parameter if present
-        if (decoded.prompt) {
+        // WHAT: Never forward prompt=login back into this retry call.
+        // WHY: authorize.js treats prompt=login as "always show the login
+        //     form," unconditionally, before it even checks whether the
+        //     user is now authenticated -- forwarding it here after a
+        //     successful Google login sends the user straight back to the
+        //     login form again, forever. Re-authentication just happened;
+        //     that job is done. Other prompt values (consent, select_account)
+        //     still have meaning post-login and are preserved.
+        if (decoded.prompt && decoded.prompt !== 'login') {
           params.set('prompt', decoded.prompt)
         }
 

--- a/pages/login.js
+++ b/pages/login.js
@@ -288,7 +288,15 @@ export default function LoginPage({
               params.set('code_challenge_method', decoded.code_challenge_method || 'S256')
             }
 
-            if (decoded.prompt) {
+            // WHAT: Never forward prompt=login back into this retry call.
+            // WHY: authorize.js treats prompt=login as "always show the login
+            //     form," unconditionally, before it even checks whether the
+            //     user is now authenticated -- forwarding it here after PIN
+            //     completion sends the user straight back to the login form
+            //     again, forever. Re-authentication just happened; that job
+            //     is done. Other prompt values (consent, select_account)
+            //     still have meaning post-login and are preserved.
+            if (decoded.prompt && decoded.prompt !== 'login') {
               params.set('prompt', decoded.prompt)
             }
             if (decoded.provider) {
@@ -297,7 +305,7 @@ export default function LoginPage({
             if (decoded.login_hint) {
               params.set('login_hint', decoded.login_hint)
             }
-            
+
             const authorizeUrl = `/api/oauth/authorize?${params.toString()}`
             console.log('[Login] After PIN, redirecting to:', authorizeUrl)
             
@@ -424,7 +432,16 @@ export default function LoginPage({
               params.set('code_challenge_method', decoded.code_challenge_method || 'S256')
             }
 
-            if (decoded.prompt) {
+            // WHAT: Never forward prompt=login back into this retry call.
+            // WHY: authorize.js treats prompt=login as "always show the login
+            //     form," unconditionally, before it even checks whether the
+            //     user is now authenticated -- forwarding it here after a
+            //     successful login/PIN completion sends the user straight
+            //     back to the login form again, forever. Re-authentication
+            //     just happened; that job is done. Other prompt values
+            //     (consent, select_account) still have meaning post-login
+            //     and are preserved.
+            if (decoded.prompt && decoded.prompt !== 'login') {
               params.set('prompt', decoded.prompt)
             }
             if (decoded.provider) {
@@ -433,10 +450,10 @@ export default function LoginPage({
             if (decoded.login_hint) {
               params.set('login_hint', decoded.login_hint)
             }
-            
+
             const authorizeUrl = `/api/oauth/authorize?${params.toString()}`
             console.log('[Login] Redirecting to:', authorizeUrl)
-            
+
             // WHAT: Verify session is set before redirect
             // WHY: Need to debug why OAuth authorize sees no session
             // HOW: Quick check to /api/sso/validate then redirect


### PR DESCRIPTION
## What's broken

Reported symptom (from messmass): log out, then immediately try to log back in — SSO shows the login form, credentials are accepted, but the user lands right back on the login form again, no matter how many times they submit. Reloading the client app first and then logging in works fine.

## Root cause

`pages/api/oauth/authorize.js` checks `prompt === 'login'` **unconditionally**, before it even checks whether the user is now authenticated:

```js
if (prompt === 'login') {
  // ...always redirect to /login?...&force_login=true, regardless of session state
}
```

Three places reconstruct the authorize retry URL after a user completes re-authentication, and all three were forwarding `prompt` from the decoded `oauth_request` unconditionally — including `login`:

- `pages/login.js` — the password-login success branch (line ~427) and the PIN-completion branch (line ~291)
- `pages/api/auth/facebook/callback.js` (line ~160)
- `pages/api/auth/google/callback.js` (line ~231)

So once a client (messmass, camera — both use `prompt=login` after logout, per OIDC's standard "force re-auth" pattern) sends `prompt=login`, every successful login attempt loops straight back to the login form instead of ever completing authorization. The user's credentials are valid and their SSO session *is* actually being established each time — they just never see it, because the retry call still carries `prompt=login` and bounces them back immediately. Reloading the client app first works because by then the client stops sending `prompt=login` on its next attempt, and the (already-valid) SSO session gets silently approved.

## Fix

Don't re-forward `prompt=login` into the retry authorize call once re-authentication has just happened — that's the one job that prompt value has, and it's done at that point. Other prompt values (`consent`, `select_account`) still have meaning post-login (they control the *next* step, not "should I have shown the login form") and are left untouched.

## Verification

- `npm run lint` — clean on all three edited files
- `npm run build` — clean, exit 0, no errors
- Could not run a live end-to-end OAuth round-trip locally — this environment can't reach the MongoDB Atlas cluster over raw TCP (connection times out; confirmed via `npm run test-connection`). The fix is a minimal, surgical change to existing, already-tested code paths (skip forwarding one specific value), traced precisely against `authorize.js`'s actual branching logic — but a real end-to-end retest of the logout→relogin flow (e.g. against messmass or camera in a preview deploy) is worth doing before/as part of merging this.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_