### PR TITLE
Changelog/release-notes entry for the prompt=login redirect-loop fix (5.31.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Universal SSO Service
 
-Version: 5.31.0  
+Version: 5.31.1  
 Status: Active  
-Last updated: 2026-07-31T00:00:00.000Z
+Last updated: 2026-08-01T00:00:00.000Z
 
 This repository contains the DoneIsBetter SSO service for `https://sso.doneisbetter.com`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture — SSO
 
-Version: 5.31.0  
-Last updated: 2026-07-31T00:00:00.000Z
+Version: 5.31.1  
+Last updated: 2026-08-01T00:00:00.000Z
 
 ## Stack
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.31.1] - 2026-08-01
+
+### 🐛 Fixed
+
+**OAuth `prompt=login` infinite redirect loop**: `authorize.js` checks `prompt === 'login'` (force re-authentication) before it checks whether the user is now authenticated. The four places that reconstruct the authorize retry URL after a client completes re-authentication — the password-login and PIN-completion branches in `pages/login.js`, and the Facebook/Google OAuth callbacks — were forwarding `prompt` from the decoded `oauth_request` unconditionally, including `login`. A consuming app sending `prompt=login` (e.g. to force fresh credentials right after a user logs out) meant every successful login attempt looped straight back to the login form instead of ever completing authorization: the user's credentials were valid and their session really was being established each time, they just never saw it, because the retry immediately bounced them back to the login form again.
+
+Fixed by dropping `prompt=login` specifically when rebuilding the retry URL at all four call sites, once re-authentication has just happened — that's the one job that value has, and it's done. Other `prompt` values (`consent`, `select_account`) still have meaning post-login and are preserved. Reported against a real consuming app (messmass): login → logout → immediate re-login failed silently every time; a full page reload before retrying "fixed" it only because it reset the client app's own in-memory "just logged out" flag that was the trigger for sending `prompt=login` in the first place.
+
+### 🔧 Changed
+- Bumped service version to `5.31.1` (patch: bug fix only, no new features or breaking changes)
+
+---
+
 ## [5.31.0] - 2026-07-31
 
 ### 🔒 Security
@@ -293,5 +306,5 @@ See Git history for changes before v5.26.0.
 ---
 
 **Maintained By:** SSO Development Team  
-**Last Updated:** 2026-07-31  
-**Current Version:** 5.31.0
+**Last Updated:** 2026-08-01  
+**Current Version:** 5.31.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # SSO Service
 
-Version: 5.31.0  
-Last updated: 2026-07-31T00:00:00.000Z
+Version: 5.31.1  
+Last updated: 2026-08-01T00:00:00.000Z
 
 This repository provides the SSO service for `https://sso.doneisbetter.com`.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,4 +1,22 @@
-# Release Notes [![Version Badge](https://img.shields.io/badge/version-5.31.0-blue)](RELEASE_NOTES.md)
+# Release Notes [![Version Badge](https://img.shields.io/badge/version-5.31.1-blue)](RELEASE_NOTES.md)
+
+## [v5.31.1] — 2026-08-01T00:00:00.000Z
+
+### 🐛 Bug Fix: OAuth `prompt=login` Infinite Redirect Loop
+
+**What**: `/api/oauth/authorize` treats `prompt=login` as "always show the login form," checked before it even looks at whether the user is now authenticated. Four places that rebuild the authorize retry URL after a client finishes re-authentication — `pages/login.js`'s password-login and PIN-completion branches, and the Facebook/Google OAuth callbacks — forwarded the client's original `prompt` value unconditionally, including `login`. A consuming app that sends `prompt=login` to force fresh credentials right after logout (a reasonable, deliberate choice — it stops a stale session from being silently reused) would see every subsequent login attempt loop straight back to the login form instead of ever completing.
+
+**Why it looked like a login failure**: the user's credentials were valid and the session really was being created each time. It just never became visible, because the immediate retry sent `prompt=login` right back to SSO, and SSO obeyed it before noticing the fresh session existed.
+
+**Symptom reported against a real consuming app (messmass)**: log in, log out, immediately try to log in again in the same browser session — redirects to SSO but never completes, no matter what's entered. Reloading the consuming app's own page before retrying "fixed" it, because that reset messmass's in-memory "we just logged out" flag, which is what triggered it to send `prompt=login` in the first place — with that flag cleared, the next attempt didn't send `prompt=login` and never hit the bug.
+
+**Fix**: the four retry-URL call sites now drop `prompt=login` specifically once re-authentication has just happened. Other `prompt` values (`consent`, `select_account`) are preserved, since those remain meaningful after login.
+
+**Files Changed**: `pages/api/oauth/authorize.js` (root cause, unconditional `prompt === 'login'` check), `pages/login.js`, `pages/api/auth/facebook/callback.js`, `pages/api/auth/google/callback.js`.
+
+**Testing**: `npm run verify` (lint, type-check, test, build, guard:repo, check:docs) clean against the fix. Confirmed live against the real messmass integration: login → logout → immediate re-login now succeeds.
+
+---
 
 ## [v5.31.0] — 2026-07-31T00:00:00.000Z
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Roadmap
 
-Version: 5.31.0  
-Last updated: 2026-07-31T00:00:00.000Z
+Version: 5.31.1  
+Last updated: 2026-08-01T00:00:00.000Z
 
 ## Recently Delivered
 

--- a/docs/TASKLIST.md
+++ b/docs/TASKLIST.md
@@ -1,7 +1,7 @@
 # Tasklist
 
-Version: 5.31.0  
-Last updated: 2026-07-31T00:00:00.000Z
+Version: 5.31.1  
+Last updated: 2026-08-01T00:00:00.000Z
 
 ## Active
 

--- a/docs/THIRD_PARTY_INTEGRATION_GUIDE.md
+++ b/docs/THIRD_PARTY_INTEGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 # Third-Party Integration Guide — SSO Service
 
-**Version**: 5.31.0  
-**Last Updated**: 2026-07-31T00:00:00.000Z  
+**Version**: 5.31.1  
+**Last Updated**: 2026-08-01T00:00:00.000Z  
 **Service URL**: https://sso.doneisbetter.com  
 **Status**: Current Runtime Guide
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moldovancsaba/universal-sso",
-  "version": "5.31.0",
+  "version": "5.31.1",
   "description": "A universal Single Sign-On (SSO) service that can be integrated into any project",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

- The `prompt=login` infinite-redirect-loop fix (#56 / commit `09b5397`) landed on `main` without a changelog or release-notes entry, leaving a gap against `CLAUDE.md`'s own "documentation ships with the change" rule.
- Bumps `package.json` and every version-stamped doc to `5.31.1` (patch: bug fix only, per this repo's own SemVer convention).
- Adds `docs/CHANGELOG.md` and `docs/RELEASE_NOTES.md` entries describing the root cause, the fix, and the real-world symptom (reported against a real consuming app, messmass — verified live: login → logout → immediate re-login now succeeds).

No code changes — docs and version numbers only.

## Test plan

- [x] `npm run check:docs` — passes
- [x] `npm run guard:repo` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMAKvqsZ25EqXVLp9vZGbJ)_