### PR TITLE
chore: migrate GDS dependency from @doneisbetter@3.0.0 to @sovereignsquad@4.1.3

### DIFF
--- a/.github/workflows/repo-guardrails.yml
+++ b/.github/workflows/repo-guardrails.yml
@@ -23,6 +23,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          # The default GITHUB_TOKEN is scoped to this repository only and cannot
+          # read @sovereignsquad/gds-* packages published under a different owner
+          # on npm.pkg.github.com (see .npmrc). Add a classic PAT with the
+          # read:packages scope and access to the sovereignsquad org's packages
+          # as a repository secret named GDS_PACKAGES_TOKEN to make this work;
+          # until then this step fails auth against the GDS registry.
+          GITHUB_TOKEN: ${{ secrets.GDS_PACKAGES_TOKEN }}
 
       - name: Enforce repository guardrails
         run: node scripts/check-repo-guardrails.mjs

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,6 @@ package-lock=true
 save-exact=true
 engine-strict=true
 legacy-peer-deps=false
+
+@sovereignsquad:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Universal SSO Service
 
-Version: 5.31.1  
+Version: 5.31.2  
 Status: Active  
-Last updated: 2026-08-01T00:00:00.000Z
+Last updated: 2026-08-08T00:00:00.000Z
 
 This repository contains the DoneIsBetter SSO service for `https://sso.doneisbetter.com`.
 

--- a/components/DocsLayout.js
+++ b/components/DocsLayout.js
@@ -10,7 +10,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core'
-import { DocsPageShell, PublicBrandFooter, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicBrandFooter, PublicShell } from '@sovereignsquad/gds-core/server'
 import packageJson from '../package.json'
 
 const docsNavigation = [

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture — SSO
 
-Version: 5.31.1  
-Last updated: 2026-08-01T00:00:00.000Z
+Version: 5.31.2  
+Last updated: 2026-08-08T00:00:00.000Z
 
 ## Stack
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.31.2] - 2026-08-08
+
+### 🔧 Changed
+
+**GDS dependency migration**: `@doneisbetter/gds-*@3.0.0` (a legacy npm-registry mirror) replaced with `@sovereignsquad/gds-*@4.1.3`, the actual current release line from the upstream `sovereignsquad/general-design-system` repo, published on GitHub Packages. Scope rename only — no component usage or contract changes.
+
+- `package.json`: `@sovereignsquad/gds`, `-admin`, `-core`, `-theme`, `gds-compliance`, and `gds-eslint-config` all moved to the new scope at `4.1.3`
+- `.npmrc`: added `@sovereignsquad` registry routing to `npm.pkg.github.com` (token via environment variable)
+- Rewrote the import specifier in all 52 source files that consumed a `@doneisbetter/gds-*` package
+- Added `@mantine/dates@9.2.1` as an explicit direct dependency to resolve an `ERESOLVE` peer conflict the upgrade introduced (GDS peer-requires `@mantine/dates`, which npm was otherwise resolving to a newer Mantine line than the rest of the app pins)
+- `gds-adoption.json` and `docs/DESIGN_SYSTEM.md` updated to the new scope, version, and alignment date; both approved exceptions are unchanged
+
+**Testing**: `npm run verify` clean. `npm run gds:validate-manifest`, `npm run gds:check`, and `npm run lint:gds` all clean.
+
+- Bumped service version to `5.31.2` (patch: dependency migration only, no behavior change)
+
+---
+
 ## [5.31.1] - 2026-08-01
 
 ### 🐛 Fixed

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,7 +1,7 @@
 # Design System Adapter
 
 Status: Mostly direct package adoption  
-Last updated: 2026-05-29
+Last updated: 2026-08-08
 
 Design / UI / UX SSOT (authoritative):
 - [GDS README](https://github.com/sovereignsquad/general-design-system/blob/main/README.md)
@@ -10,57 +10,56 @@ Design / UI / UX SSOT (authoritative):
 - [Governance & Adoption](https://github.com/sovereignsquad/general-design-system/blob/main/GOVERNANCE_AND_ADOPTION.md)
 - [Adoption & Migration Playbook](https://github.com/sovereignsquad/general-design-system/blob/main/ADOPTION_AND_MIGRATION_PLAYBOOK.md)
 - [Compliance Toolkit](https://github.com/sovereignsquad/general-design-system/blob/main/COMPLIANCE_TOOLKIT.md)
-- Optional local checkout mirror: [general-design-system](/Users/Shared/Projects/general-design-system) (non-authoritative convenience copy)
 
-Aligned SSOT version/date: `2.6.3 / 2026-05-27`
+Aligned SSOT version/date: `4.1.3 / 2026-08-08`
 
 This file records only local adapter state, migration blockers, validation commands, and approved exceptions. The shared GDS repo is authoritative for design rules, runtime contracts, and package usage.
 
 ## Current Truth
 
 - Canonical package names are now:
-  - `@doneisbetter/gds-theme`
-  - `@doneisbetter/gds-core`
-  - `@doneisbetter/gds-admin`
-  - `@doneisbetter/gds-eslint-config`
-  - `@doneisbetter/gds-compliance`
+  - `@sovereignsquad/gds-theme`
+  - `@sovereignsquad/gds-core`
+  - `@sovereignsquad/gds-admin`
+  - `@sovereignsquad/gds-eslint-config`
+  - `@sovereignsquad/gds-compliance`
 - Canonical import split is now:
-  - `@doneisbetter/gds-theme/client`
-  - `@doneisbetter/gds-theme/server`
-  - `@doneisbetter/gds-core/client`
-  - `@doneisbetter/gds-core/server`
-  - `@doneisbetter/gds-admin/client`
-  - `@doneisbetter/gds-admin/server`
+  - `@sovereignsquad/gds-theme/client`
+  - `@sovereignsquad/gds-theme/server`
+  - `@sovereignsquad/gds-core/client`
+  - `@sovereignsquad/gds-core/server`
+  - `@sovereignsquad/gds-admin/client`
+  - `@sovereignsquad/gds-admin/server`
 
 ## Current Repo State
 
 - Current UI foundation: direct GDS runtime packages with one remaining local UI adapter (`DocsLayout`)
-- Current root provider wiring: [pages/_app.js](../pages/_app.js) via direct `@doneisbetter/gds-theme/client`
-- Current token/theme authority: [lib/theme/mantineTheme.js](../lib/theme/mantineTheme.js) via `@doneisbetter/gds-theme/server`
+- Current root provider wiring: [pages/_app.js](../pages/_app.js) via direct `@sovereignsquad/gds-theme/client`
+- Current token/theme authority: [lib/theme/mantineTheme.js](../lib/theme/mantineTheme.js) via `@sovereignsquad/gds-theme/server`
 - Current app root wiring: [pages/_app.js](../pages/_app.js)
 - Current manifest: [gds-adoption.json](../gds-adoption.json)
 - Installed runtime packages:
-  - `@doneisbetter/gds-theme@2.6.3`
-  - `@doneisbetter/gds-core@2.6.3`
-  - `@doneisbetter/gds-admin@2.6.3`
+  - `@sovereignsquad/gds-theme@4.1.3`
+  - `@sovereignsquad/gds-core@4.1.3`
+  - `@sovereignsquad/gds-admin@4.1.3`
 
 ## Current Direct Consumption
 
-- `@doneisbetter/gds-theme/client`
+- `@sovereignsquad/gds-theme/client`
   - [pages/_app.js](../pages/_app.js)
-- `@doneisbetter/gds-theme/server`
+- `@sovereignsquad/gds-theme/server`
   - [lib/theme/mantineTheme.js](../lib/theme/mantineTheme.js)
-- `@doneisbetter/gds-core/server`
+- `@sovereignsquad/gds-core/server`
   - [pages/login.js](../pages/login.js), [pages/register.js](../pages/register.js), [pages/forgot-password.js](../pages/forgot-password.js), [pages/logout.js](../pages/logout.js), [pages/admin/index.js](../pages/admin/index.js), [pages/admin/callback.js](../pages/admin/callback.js), and [pages/admin/forgot-password.js](../pages/admin/forgot-password.js) via direct `AuthShell`
   - [pages/admin/users.js](../pages/admin/users.js) and [pages/admin/activity.js](../pages/admin/activity.js) via direct `DataToolbar`
   - [components/DocsLayout.js](../components/DocsLayout.js)
   - [pages/index.js](../pages/index.js) via `PublicShell`, `EditorialHero`, `FeatureBand`, `ConsumerSection`, `ConsumerDashboardGrid`, `EditorialCard`, `AccentPanel`, and `CtaButtonGroup`
   - [pages/privacy.js](../pages/privacy.js), [pages/terms.js](../pages/terms.js), [pages/data-deletion.js](../pages/data-deletion.js), and [pages/test-fetch.js](../pages/test-fetch.js) via direct `PublicShell`, `PublicBrandFooter`, and `ArticleShell`
   - editorial callouts on core docs pages via `AccentPanel`
-- `@doneisbetter/gds-admin/client`
+- `@sovereignsquad/gds-admin/client`
   - [pages/admin/users.js](../pages/admin/users.js)
   - [pages/admin/oauth-clients.js](../pages/admin/oauth-clients.js)
-- `@doneisbetter/gds-admin/server`
+- `@sovereignsquad/gds-admin/server`
   - [pages/admin/dashboard.js](../pages/admin/dashboard.js), [pages/admin/users.js](../pages/admin/users.js), [pages/admin/activity.js](../pages/admin/activity.js), and [pages/admin/oauth-clients.js](../pages/admin/oauth-clients.js) via direct `PageHeader`
   - [pages/account.js](../pages/account.js) and [pages/demo.js](../pages/demo.js) via direct `PageHeader`
 
@@ -130,7 +129,7 @@ Current repo usage proves the public/editorial family is viable on this runtime 
 ## Rules For This Repo
 
 - Do not add new old-placeholder package references.
-- Prefer direct `@doneisbetter/*` imports when a stable package contract already exists.
+- Prefer direct `@sovereignsquad/*` imports when a stable package contract already exists.
 - Do not create a second local token or provider authority.
 - Keep local wrappers thin and temporary.
 - Prefer deleting mirrored local contracts family-by-family once direct package imports are actually viable.
@@ -144,7 +143,7 @@ Current repo usage proves the public/editorial family is viable on this runtime 
 - `npm run build`
 - `npm run check:docs`
 
-`npm run lint` remains the repo's existing baseline lint contract. `npm run lint:gds` wires the shared `@doneisbetter/gds-eslint-config` package and now runs cleanly with only two explicit localized waivers left on long-form docs copy plus the existing server-generated HTML response template exceptions.
+`npm run lint` remains the repo's existing baseline lint contract. `npm run lint:gds` wires the shared `@sovereignsquad/gds-eslint-config` package and now runs cleanly with only two explicit localized waivers left on long-form docs copy plus the existing server-generated HTML response template exceptions.
 
 ## Next Honest Migration Step
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # SSO Service
 
-Version: 5.31.1  
-Last updated: 2026-08-01T00:00:00.000Z
+Version: 5.31.2  
+Last updated: 2026-08-08T00:00:00.000Z
 
 This repository provides the SSO service for `https://sso.doneisbetter.com`.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,4 +1,27 @@
-# Release Notes [![Version Badge](https://img.shields.io/badge/version-5.31.1-blue)](RELEASE_NOTES.md)
+# Release Notes [![Version Badge](https://img.shields.io/badge/version-5.31.2-blue)](RELEASE_NOTES.md)
+
+## [v5.31.2] — 2026-08-08T00:00:00.000Z
+
+### 🔧 Dependency Migration: GDS `@doneisbetter` → `@sovereignsquad` (v4.1.3)
+
+**What**: The design-system dependency was still pinned to `@doneisbetter/gds-*@3.0.0`, a legacy npm-registry mirror of the General Design System. The actual upstream project (`sovereignsquad/general-design-system`) has moved on to `@sovereignsquad/gds-*@4.1.3`, published on GitHub Packages — the `@doneisbetter` mirror is no longer the current release line.
+
+**Why**: Staying on the old scope/version meant SSO was tracking a dead mirror instead of the real upstream package, missing three major versions' worth of upstream fixes and contract updates with no path back onto the maintained line.
+
+**Changes**:
+- `package.json`: `@doneisbetter/gds`, `-admin`, `-core`, `-theme`, and the `gds-compliance`/`gds-eslint-config` dev tooling all moved from the `@doneisbetter` scope to `@sovereignsquad`, pinned at `4.1.3`
+- `.npmrc`: added GitHub Packages registry routing for the `@sovereignsquad` scope (`_authToken` sourced from an environment variable, never a literal secret)
+- Rewrote the import specifier in all 52 source files that consumed a `@doneisbetter/gds-*` package — subpaths and named imports unchanged, this was a scope rename only, not a contract change
+- Added `@mantine/dates@9.2.1` as an explicit direct dependency: the upgrade pulled in a `@mantine/dates` peer requirement that npm was resolving to a newer Mantine line than the rest of the app pins, producing an `ERESOLVE` conflict; pinning it explicitly at the same version as the rest of the Mantine family resolved it at the source instead of forcing past it
+- `gds-adoption.json` and `docs/DESIGN_SYSTEM.md` updated to the new scope, version, and alignment date; both approved exceptions (OAuth provider buttons, docs editorial shell) are unchanged by this migration
+
+**Not changed**: no component usage, contract, or visual behavior changed — this is a dependency-identity migration only. `lib/theme/mantineTheme.js` continues to use `extendGdsTheme` from `@sovereignsquad/gds-theme/server`, confirmed still functional upstream (soft-deprecated, not removed); migrating it to `createPublicBrandTheme` is left for a follow-up.
+
+**Testing**: `npm run verify` (lint, type-check, test, build, guard:repo, check:docs) clean. `npm run gds:validate-manifest`, `npm run gds:check`, and `npm run lint:gds` all clean against the new manifest and package versions.
+
+**Files Changed**: `package.json`, `package-lock.json`, `.npmrc`, `gds-adoption.json`, `docs/DESIGN_SYSTEM.md`, and 52 source files under `pages/`, `lib/`, and `components/` (import specifier only).
+
+---
 
 ## [v5.31.1] — 2026-08-01T00:00:00.000Z
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Roadmap
 
-Version: 5.31.1  
-Last updated: 2026-08-01T00:00:00.000Z
+Version: 5.31.2  
+Last updated: 2026-08-08T00:00:00.000Z
 
 ## Recently Delivered
 
@@ -15,6 +15,12 @@ Last updated: 2026-08-01T00:00:00.000Z
 - Fixed three admin login flows that issued unparseable session cookies
 - Replaced generic "Internal server error" responses with actionable detail across authenticated admin/API routes
 - Delivered Phase 1 (documentation and operator alignment): reconciled core markdown docs and `pages/docs` surfaces with the shipped runtime contract, see `docs/CHANGELOG.md` [5.31.0]
+
+### GDS 4.1.3 migration completed in August 2026
+- Migrated the design-system dependency from the retired `@doneisbetter/gds-*` GitHub Packages mirror to the canonical `@sovereignsquad/gds-*@4.1.3` packages published by the upstream `sovereignsquad/general-design-system` repo
+- Rewrote all 52 source files' GDS import specifiers to the new scope; no component usage or contract changes were required
+- Added `@mantine/dates@9.2.1` as an explicit direct dependency to resolve a peer-dependency conflict introduced by the upgrade
+- Updated `gds-adoption.json` and `docs/DESIGN_SYSTEM.md` to the new package scope and version; approved exceptions and migration gaps are unchanged
 
 ### Multi-app authorization foundation
 - Central `appPermissions` model

--- a/docs/TASKLIST.md
+++ b/docs/TASKLIST.md
@@ -1,7 +1,7 @@
 # Tasklist
 
-Version: 5.31.1  
-Last updated: 2026-08-01T00:00:00.000Z
+Version: 5.31.2  
+Last updated: 2026-08-08T00:00:00.000Z
 
 ## Active
 

--- a/docs/THIRD_PARTY_INTEGRATION_GUIDE.md
+++ b/docs/THIRD_PARTY_INTEGRATION_GUIDE.md
@@ -1,7 +1,7 @@
 # Third-Party Integration Guide — SSO Service
 
-**Version**: 5.31.1  
-**Last Updated**: 2026-08-01T00:00:00.000Z  
+**Version**: 5.31.2  
+**Last Updated**: 2026-08-08T00:00:00.000Z  
 **Service URL**: https://sso.doneisbetter.com  
 **Status**: Current Runtime Guide
 

--- a/eslint.gds.config.mjs
+++ b/eslint.gds.config.mjs
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { FlatCompat } from '@eslint/eslintrc'
-import gdsConfig from '@doneisbetter/gds-eslint-config'
+import gdsConfig from '@sovereignsquad/gds-eslint-config'
 
 const compat = new FlatCompat({
   baseDirectory: dirname(fileURLToPath(import.meta.url)),

--- a/gds-adoption.json
+++ b/gds-adoption.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
-  "gdsVersion": "3.0.0",
+  "gdsVersion": "4.1.3",
   "productArchetype": "hybrid",
   "supportedEntryPoints": [
-    "@doneisbetter/gds-theme/client",
-    "@doneisbetter/gds-theme/server",
-    "@doneisbetter/gds-core/server",
-    "@doneisbetter/gds-admin/client",
-    "@doneisbetter/gds-admin/server"
+    "@sovereignsquad/gds-theme/client",
+    "@sovereignsquad/gds-theme/server",
+    "@sovereignsquad/gds-core/server",
+    "@sovereignsquad/gds-admin/client",
+    "@sovereignsquad/gds-admin/server"
   ],
   "requiredContracts": [
     "AppShell",
@@ -40,9 +40,9 @@
       ],
       "allowedImplementation": "Narrow custom provider-branded CTA treatment only where provider brand policy requires it.",
       "mustStillUse": [
-        "@doneisbetter/gds-core/server",
-        "@doneisbetter/gds-theme/client",
-        "@doneisbetter/gds-theme/server"
+        "@sovereignsquad/gds-core/server",
+        "@sovereignsquad/gds-theme/client",
+        "@sovereignsquad/gds-theme/server"
       ],
       "mustNotDo": [
         "Introduce a parallel local design system",
@@ -67,9 +67,9 @@
       ],
       "allowedImplementation": "Use local docs-shell wrapper only for docs navigation/framing while pages consume GDS primitives directly where available.",
       "mustStillUse": [
-        "@doneisbetter/gds-core/server",
-        "@doneisbetter/gds-theme/client",
-        "@doneisbetter/gds-theme/server"
+        "@sovereignsquad/gds-core/server",
+        "@sovereignsquad/gds-theme/client",
+        "@sovereignsquad/gds-theme/server"
       ],
       "mustNotDo": [
         "Reintroduce local design-token authority",

--- a/lib/docs-shell-config.js
+++ b/lib/docs-shell-config.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Anchor, Badge, Box, Group, NavLink, ScrollArea, Stack, Text } from '@mantine/core'
-import { PublicBrandFooter } from '@doneisbetter/gds-core/server'
+import { PublicBrandFooter } from '@sovereignsquad/gds-core/server'
 import packageJson from '../package.json'
 
 const docsSections = [

--- a/lib/theme/mantineTheme.js
+++ b/lib/theme/mantineTheme.js
@@ -1,4 +1,4 @@
-import { extendGdsTheme } from '@doneisbetter/gds-theme/server'
+import { extendGdsTheme } from '@sovereignsquad/gds-theme/server'
 
 export const mantineThemeOverrides = {
   primaryColor: 'brand',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,24 @@
 {
   "name": "@moldovancsaba/universal-sso",
-  "version": "5.29.0",
+  "version": "5.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moldovancsaba/universal-sso",
-      "version": "5.29.0",
+      "version": "5.31.1",
       "license": "MIT",
       "dependencies": {
-        "@doneisbetter/gds": "3.0.0",
-        "@doneisbetter/gds-admin": "3.0.0",
-        "@doneisbetter/gds-core": "3.0.0",
-        "@doneisbetter/gds-theme": "3.0.0",
         "@mantine/core": "9.2.1",
+        "@mantine/dates": "9.2.1",
         "@mantine/form": "9.2.1",
         "@mantine/hooks": "9.2.1",
         "@mantine/modals": "9.2.1",
         "@mantine/notifications": "9.2.1",
+        "@sovereignsquad/gds": "4.1.3",
+        "@sovereignsquad/gds-admin": "4.1.3",
+        "@sovereignsquad/gds-core": "4.1.3",
+        "@sovereignsquad/gds-theme": "4.1.3",
         "@tabler/icons-react": "3.44.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -35,8 +36,8 @@
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@doneisbetter/gds-compliance": "3.0.0",
-        "@doneisbetter/gds-eslint-config": "3.0.0",
+        "@sovereignsquad/gds-compliance": "4.1.3",
+        "@sovereignsquad/gds-eslint-config": "4.1.3",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/node": "^20.19.40",
@@ -596,81 +597,57 @@
         "kuler": "^2.0.0"
       }
     },
-    "node_modules/@doneisbetter/gds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds/-/gds-3.0.0.tgz",
-      "integrity": "sha512-Rg2oClENSVQKFOY0MCSWxpyfx2rG2OItg2aQiIA7NvD0a5QoJlj5Blnx7EUHEFSojGRKh2blqIQedkYyrwxAfw==",
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
       "dependencies": {
-        "@doneisbetter/gds-admin": "^3.0.0",
-        "@doneisbetter/gds-core": "^3.0.0",
-        "@doneisbetter/gds-theme": "^3.0.0"
+        "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/modals": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/notifications": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@tabler/icons-react": "^3.5.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react": ">=16.8.0"
       }
     },
-    "node_modules/@doneisbetter/gds-admin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds-admin/-/gds-admin-3.0.0.tgz",
-      "integrity": "sha512-WmqaphgkEXmj4QIJ3FTkE6OImEbbMXMhZeymJk/tYOt4rJaV80v0hLa5AY7i9z6Q/p4IZleDHB4Ys8bBB1WFew==",
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
       "peerDependencies": {
-        "@doneisbetter/gds-core": "^3.0.0",
-        "@doneisbetter/gds-theme": "^3.0.0",
-        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@tabler/icons-react": "^3.5.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@doneisbetter/gds-compliance": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds-compliance/-/gds-compliance-3.0.0.tgz",
-      "integrity": "sha512-AQK6SMPRO8DXBnuMrQ+fH34e6KhxZ12MZ8dmWsoOjoBqgAIOeRi7fL2ahuJpx1BDVzQin+cbQPy78BHw0nTQiA==",
-      "dev": true,
-      "bin": {
-        "gds-compliance": "bin/gds-compliance.js"
-      }
-    },
-    "node_modules/@doneisbetter/gds-core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds-core/-/gds-core-3.0.0.tgz",
-      "integrity": "sha512-goJ8nRrrp1St2TgnLoBqNLgQy2qW8V8GgBQwJTmRhwHvN4kuyOyWtJKFbKNI8GQM88uQMSpszqVXCPqV5m5uaA==",
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
       "peerDependencies": {
-        "@doneisbetter/gds-theme": "^3.0.0",
-        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@tabler/icons-react": "^3.5.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
-    "node_modules/@doneisbetter/gds-eslint-config": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds-eslint-config/-/gds-eslint-config-3.0.0.tgz",
-      "integrity": "sha512-WAUvb+Tb3QacYtc+gzXiFLO2PmGdV36KKUx9By9yke7h1FmmosbB8rsbCRbqhQTL7HhjhIUjMHJw2SUaAJtLwA==",
-      "dev": true,
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
       "peerDependencies": {
-        "eslint": "^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@doneisbetter/gds-theme": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doneisbetter/gds-theme/-/gds-theme-3.0.0.tgz",
-      "integrity": "sha512-pa5z6l5XRse9xQTaUbjDx5JyweTOoMk/FNMZ3B4wyFnK8OtP/+x9Payf45h26/1XXZEFau4Bib1ssnF40Za9eg==",
-      "peerDependencies": {
-        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/modals": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "@mantine/notifications": "^7.9.0 || ^8.3.0 || ^9.0.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1927,6 +1904,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@mantine/dates": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.2.1.tgz",
+      "integrity": "sha512-cyRC8bnZ6W+SzQf/RM+/eDeWhZTZF148z+OcgqiERdkAujh0q88Ddybv/Hshv1EOf0rCe6oiHSZWxIxmUf7KAg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@mantine/core": "9.2.1",
+        "@mantine/hooks": "9.2.1",
+        "dayjs": ">=1.0.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
     "node_modules/@mantine/form": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.2.1.tgz",
@@ -2252,6 +2245,104 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@sovereignsquad/gds": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds/4.1.3/2455c5d0cfd8495200bfd3ddfaab3fbd997fd550",
+      "integrity": "sha512-FORhZIny/0m7R6LP39qaJoS7DN4Rd2phgyBzmTnLLosTqt3UwzwHVQzb57BSV2Ys/llr8gHaGhK8wnDZ62cu4g==",
+      "dependencies": {
+        "@sovereignsquad/gds-admin": "4.1.3",
+        "@sovereignsquad/gds-core": "4.1.3",
+        "@sovereignsquad/gds-theme": "4.1.3"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/dates": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/modals": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/notifications": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@tabler/icons-react": "^3.5.0",
+        "dayjs": ">=1.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@sovereignsquad/gds-admin": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds-admin/4.1.3/1933a6e88d9de0592948b6285d8315f184ede316",
+      "integrity": "sha512-ZvBfecQxbVj+kve2mcPNlT7RgQFrhBTjC5pu6HFuewuZv/GMUA6yuhDp3LdUrvRU1GzSPSgzb41aYIn/x8jkew==",
+      "dependencies": {
+        "@sovereignsquad/gds-core": "4.1.3",
+        "@sovereignsquad/gds-theme": "4.1.3"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@sovereignsquad/gds-core": "4.1.3",
+        "@sovereignsquad/gds-theme": "4.1.3",
+        "@tabler/icons-react": "^3.5.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@sovereignsquad/gds-compliance": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds-compliance/4.1.3/f27ebeb34fe142f515d86a33b1f96620aa5c7120",
+      "integrity": "sha512-/VAml7dEufc6ylAgHCOxhi1Ao1IajwvlvNiFIpOO1aUzLnGXIt/ea8PwQruuEVRrn3rWPnFlVzJ8yrorbbrhcA==",
+      "dev": true,
+      "bin": {
+        "gds-compliance": "bin/gds-compliance.js"
+      }
+    },
+    "node_modules/@sovereignsquad/gds-core": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds-core/4.1.3/38d87070c29bf4fa91ca5b3112bed7dab72bdc68",
+      "integrity": "sha512-WVPH8Utno5CozXkLPaaZQZpWm3jDzKZdvWJf68WYoGmihdl5eoMySj9l2mfxMMgEyH+ov0XmEofyThseJ4KpgA==",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@sovereignsquad/gds-theme": "4.1.3",
+        "@tiptap/core": "^3.28.0",
+        "@tiptap/pm": "^3.28.0",
+        "@tiptap/react": "^3.28.0",
+        "@tiptap/starter-kit": "^3.28.0"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/dates": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@sovereignsquad/gds-theme": "4.1.3",
+        "@tabler/icons-react": "^3.5.0",
+        "dayjs": ">=1.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@sovereignsquad/gds-eslint-config": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds-eslint-config/4.1.3/7d4b8e3612316eb664391c29ab142e3dab1511af",
+      "integrity": "sha512-Qn0UEz+RzAvHCV87xUKsar/1SngxjGGnwFIGxiq1DxO1HB8+SVXY36fnZZpvB5C/YT8+A0W0EszTbflyxyks8A==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@sovereignsquad/gds-theme": {
+      "version": "4.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@sovereignsquad/gds-theme/4.1.3/66841af7564c966ad84c94b5ed53ba467b8c460e",
+      "integrity": "sha512-akqc5NJi+ZukLF2z0zC58txnA417r2pqdHcl/hppT29HaEezod0J+VIhsCVynNgyx7HN/GDALngXqZPKKMVhRQ==",
+      "bin": {
+        "gds-theme-tokens": "bin/gds-theme-tokens.mjs"
+      },
+      "peerDependencies": {
+        "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/modals": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "@mantine/notifications": "^7.9.0 || ^8.3.0 || ^9.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2291,6 +2382,436 @@
       },
       "peerDependencies": {
         "react": ">= 16"
+      }
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
+      "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
+      "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
+      "integrity": "sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
+      "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
+      "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
+      "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
+      "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
+      "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
+      "integrity": "sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
+      "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
+      "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
+      "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
+      "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
+      "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
+      "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
+      "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
+      "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
+      "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
+      "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
+      "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
+      "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
+      "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
+      "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
+      "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
+      "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.29.2.tgz",
+      "integrity": "sha512-ZMKgteYmZXnq7C22U9fbCTC6jAF8XlQM5n2K2FLWCdYAlP4FNV3XeQ9hY2a13KSQ0Q3yltWXZlcWBpt5ClxScg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.29.2",
+        "@tiptap/extension-floating-menu": "^3.29.2"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
+      "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.29.2",
+        "@tiptap/extension-blockquote": "^3.29.2",
+        "@tiptap/extension-bold": "^3.29.2",
+        "@tiptap/extension-bullet-list": "^3.29.2",
+        "@tiptap/extension-code": "^3.29.2",
+        "@tiptap/extension-code-block": "^3.29.2",
+        "@tiptap/extension-document": "^3.29.2",
+        "@tiptap/extension-dropcursor": "^3.29.2",
+        "@tiptap/extension-gapcursor": "^3.29.2",
+        "@tiptap/extension-hard-break": "^3.29.2",
+        "@tiptap/extension-heading": "^3.29.2",
+        "@tiptap/extension-horizontal-rule": "^3.29.2",
+        "@tiptap/extension-italic": "^3.29.2",
+        "@tiptap/extension-link": "^3.29.2",
+        "@tiptap/extension-list": "^3.29.2",
+        "@tiptap/extension-list-item": "^3.29.2",
+        "@tiptap/extension-list-keymap": "^3.29.2",
+        "@tiptap/extension-ordered-list": "^3.29.2",
+        "@tiptap/extension-paragraph": "^3.29.2",
+        "@tiptap/extension-strike": "^3.29.2",
+        "@tiptap/extension-text": "^3.29.2",
+        "@tiptap/extension-underline": "^3.29.2",
+        "@tiptap/extensions": "^3.29.2",
+        "@tiptap/pm": "^3.29.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2446,10 +2967,19 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2463,6 +2993,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
@@ -4111,6 +4647,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5109,6 +5652,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -7214,6 +7766,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7899,6 +8457,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -8253,6 +8817,145 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -8652,6 +9355,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -9923,6 +10632,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9952,6 +10670,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moldovancsaba/universal-sso",
-  "version": "5.31.1",
+  "version": "5.31.2",
   "description": "A universal Single Sign-On (SSO) service that can be integrated into any project",
   "main": "src/index.ts",
   "type": "module",
@@ -37,11 +37,12 @@
   "author": "Moldovan Csaba",
   "license": "MIT",
   "dependencies": {
-    "@doneisbetter/gds": "3.0.0",
-    "@doneisbetter/gds-admin": "3.0.0",
-    "@doneisbetter/gds-core": "3.0.0",
-    "@doneisbetter/gds-theme": "3.0.0",
+    "@sovereignsquad/gds": "4.1.3",
+    "@sovereignsquad/gds-admin": "4.1.3",
+    "@sovereignsquad/gds-core": "4.1.3",
+    "@sovereignsquad/gds-theme": "4.1.3",
     "@mantine/core": "9.2.1",
+    "@mantine/dates": "9.2.1",
     "@mantine/form": "9.2.1",
     "@mantine/hooks": "9.2.1",
     "@mantine/modals": "9.2.1",
@@ -63,8 +64,8 @@
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@doneisbetter/gds-compliance": "3.0.0",
-    "@doneisbetter/gds-eslint-config": "3.0.0",
+    "@sovereignsquad/gds-compliance": "4.1.3",
+    "@sovereignsquad/gds-eslint-config": "4.1.3",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.0",
     "@types/node": "^20.19.40",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import '@mantine/notifications/styles.css';
 import '../styles/globals.css';
 import { useState, useEffect, useCallback } from 'react';
 import { notifications } from '@mantine/notifications';
-import { GdsProvider } from '@doneisbetter/gds-theme/client';
+import { GdsProvider } from '@sovereignsquad/gds-theme/client';
 import { useRouter } from 'next/router';
 import { mantineTheme } from '../lib/theme/mantineTheme';
 

--- a/pages/account.js
+++ b/pages/account.js
@@ -16,7 +16,7 @@ import {
   Text,
   TextInput,
 } from '@mantine/core'
-import { PageHeader } from '@doneisbetter/gds-admin/server'
+import { PageHeader } from '@sovereignsquad/gds-admin/server'
 import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react'
 
 export async function getServerSideProps(context) {

--- a/pages/admin/activity.js
+++ b/pages/admin/activity.js
@@ -17,8 +17,8 @@ import {
   Text,
 } from '@mantine/core'
 import { IconAlertCircle, IconLogout } from '@tabler/icons-react'
-import { DataToolbar, StateBlock } from '@doneisbetter/gds-core/server'
-import { PageHeader } from '@doneisbetter/gds-admin/server'
+import { DataToolbar, StateBlock } from '@sovereignsquad/gds-core/server'
+import { PageHeader } from '@sovereignsquad/gds-admin/server'
 
 export async function getServerSideProps(context) {
   const { getAdminUser } = await import('../../lib/auth.mjs')

--- a/pages/admin/callback.js
+++ b/pages/admin/callback.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Alert, Box, Button, Loader, Stack, Text, ThemeIcon } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertCircle, IconLock } from '@tabler/icons-react'
 import { decodeAdminLoginState, sanitizeAdminRedirectPath } from '../../lib/adminAuthFlow.js'
 

--- a/pages/admin/dashboard.js
+++ b/pages/admin/dashboard.js
@@ -25,7 +25,7 @@ import {
   IconUsers,
 } from '@tabler/icons-react'
 import { fetchAdminJson, isAuthRedirectError } from '../../lib/adminAuthFlow.js'
-import { PageHeader as GdsPageHeader } from '@doneisbetter/gds-admin/server'
+import { PageHeader as GdsPageHeader } from '@sovereignsquad/gds-admin/server'
 
 const adminNavItems = [
   { href: '/admin/dashboard', label: 'Dashboard' },

--- a/pages/admin/forgot-password.js
+++ b/pages/admin/forgot-password.js
@@ -11,7 +11,7 @@ import {
   Text,
   TextInput,
 } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react'
 
 export async function getServerSideProps() {

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { Box, Loader, Stack, Text, ThemeIcon } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconLock } from '@tabler/icons-react'
 import { encodeAdminLoginState, sanitizeAdminRedirectPath } from '../../lib/adminAuthFlow.js'
 

--- a/pages/admin/oauth-clients.js
+++ b/pages/admin/oauth-clients.js
@@ -27,8 +27,8 @@ import {
   IconLogout,
   IconPlus,
 } from '@tabler/icons-react'
-import { ResponsiveDataView } from '@doneisbetter/gds-admin/client'
-import { PageHeader } from '@doneisbetter/gds-admin/server'
+import { ResponsiveDataView } from '@sovereignsquad/gds-admin/client'
+import { PageHeader } from '@sovereignsquad/gds-admin/server'
 import { fetchAdminJson, isAuthRedirectError } from '../../lib/adminAuthFlow.js'
 
 const adminNavItems = [

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -22,9 +22,9 @@ import {
   Title,
 } from '@mantine/core'
 import { IconAlertCircle, IconCircleCheck, IconLogout } from '@tabler/icons-react'
-import { DataToolbar, StateBlock } from '@doneisbetter/gds-core/server'
-import { ResponsiveDataView } from '@doneisbetter/gds-admin/client'
-import { PageHeader } from '@doneisbetter/gds-admin/server'
+import { DataToolbar, StateBlock } from '@sovereignsquad/gds-core/server'
+import { ResponsiveDataView } from '@sovereignsquad/gds-admin/client'
+import { PageHeader } from '@sovereignsquad/gds-admin/server'
 import { fetchAdminJson, isAuthRedirectError } from '../../lib/adminAuthFlow.js'
 
 const adminNavItems = [

--- a/pages/data-deletion.js
+++ b/pages/data-deletion.js
@@ -12,7 +12,7 @@ import {
   Text,
   Title,
 } from '@mantine/core'
-import { ArticleShell, PublicBrandFooter, PublicShell } from '@doneisbetter/gds-core/server'
+import { ArticleShell, PublicBrandFooter, PublicShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertTriangle, IconCheck, IconInfoCircle, IconTrash } from '@tabler/icons-react'
 
 export default function DataDeletionPage() {

--- a/pages/demo.js
+++ b/pages/demo.js
@@ -17,7 +17,7 @@ import {
   ThemeIcon,
   Title,
 } from '@mantine/core'
-import { PageHeader } from '@doneisbetter/gds-admin/server'
+import { PageHeader } from '@sovereignsquad/gds-admin/server'
 import { IconCheck, IconLogout } from '@tabler/icons-react'
 import { getPublicUserFromRequest } from '../lib/publicSessions.mjs'
 

--- a/pages/docs/admin-approval.js
+++ b/pages/docs/admin-approval.js
@@ -9,7 +9,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel } from '@doneisbetter/gds-core/server'
+import { AccentPanel } from '@sovereignsquad/gds-core/server'
 // WHAT: Admin Approval Process documentation for SSO administrators
 // WHY: SSO admins need guidance on managing user access to apps
 // HOW: Step-by-step workflows for granting/revoking app permissions

--- a/pages/docs/api/endpoints.js
+++ b/pages/docs/api/endpoints.js
@@ -6,7 +6,7 @@ import {
   List,
   Box,
 } from '@mantine/core'
-import { DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 
 export default function ApiEndpoints() {

--- a/pages/docs/api/errors.js
+++ b/pages/docs/api/errors.js
@@ -4,7 +4,7 @@ import {
   Text,
   Box,
 } from '@mantine/core'
-import { DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 
 export default function ApiErrors() {

--- a/pages/docs/api/index.js
+++ b/pages/docs/api/index.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Anchor, Box, List, Stack, Text, Title } from '@mantine/core'
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 
 export default function ApiDocs() {

--- a/pages/docs/api/responses.js
+++ b/pages/docs/api/responses.js
@@ -5,7 +5,7 @@ import {
   Code,
   Box,
 } from '@mantine/core'
-import { DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 
 export default function ApiResponses() {

--- a/pages/docs/app-permissions.js
+++ b/pages/docs/app-permissions.js
@@ -9,8 +9,8 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel } from '@doneisbetter/gds-core/server'
-import { DocsCodeBlock } from '@doneisbetter/gds-core/client'
+import { AccentPanel } from '@sovereignsquad/gds-core/server'
+import { DocsCodeBlock } from '@sovereignsquad/gds-core/client'
 // WHAT: App Permissions documentation explaining permission lifecycle
 // WHY: Developers need to understand how app-level permissions work in SSO
 // HOW: Explains pending → approved → revoked states and role management

--- a/pages/docs/authentication.js
+++ b/pages/docs/authentication.js
@@ -6,7 +6,7 @@ import {
   List,
   Box,
 } from '@mantine/core';
-import { DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../lib/docs-shell-config'
 
 export default function Authentication() {

--- a/pages/docs/error-handling.js
+++ b/pages/docs/error-handling.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel } from '@doneisbetter/gds-core/server'
+import { AccentPanel } from '@sovereignsquad/gds-core/server'
 // WHAT: Error handling guide for OAuth 2.0 and app permission errors
 // WHY: Developers need practical error handling patterns for production apps
 // HOW: Covers OAuth errors, app permission errors, and best practices

--- a/pages/docs/examples/react.js
+++ b/pages/docs/examples/react.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: React OAuth 2.0 integration example with complete implementation
 // WHY: Developers need copy-paste ready code for React apps using SSO

--- a/pages/docs/examples/vanilla.js
+++ b/pages/docs/examples/vanilla.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: Vanilla JavaScript OAuth 2.0 integration example without frameworks
 // WHY: Developers need pure JavaScript implementation for non-framework projects

--- a/pages/docs/examples/vue.js
+++ b/pages/docs/examples/vue.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: Vue.js OAuth 2.0 integration example with Pinia store
 // WHY: Developers need copy-paste ready code for Vue 3 apps using SSO

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -7,7 +7,7 @@ import {
   List,
   Box,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../lib/docs-shell-config'
 
 export default function DocsPage() {

--- a/pages/docs/installation.js
+++ b/pages/docs/installation.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../lib/docs-shell-config'
 // WHAT: Integration guide for developers adding SSO to their applications
 // WHY: Developers need clear steps to integrate OAuth 2.0 SSO into their apps

--- a/pages/docs/integration.js
+++ b/pages/docs/integration.js
@@ -6,7 +6,7 @@ import {
   List,
   Box,
 } from '@mantine/core';
-import { DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../lib/docs-shell-config'
 
 export default function IntegrationGuidePage() {

--- a/pages/docs/quickstart.js
+++ b/pages/docs/quickstart.js
@@ -7,7 +7,7 @@ import {
   List,
   Box,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../lib/docs-shell-config'
 
 export default function Quickstart() {

--- a/pages/docs/return-url-handling.js
+++ b/pages/docs/return-url-handling.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel } from '@doneisbetter/gds-core/server'
+import { AccentPanel } from '@sovereignsquad/gds-core/server'
 // WHAT: Documentation for handling return URLs in OAuth flow
 // WHY: Developers need guidance on preserving user's location through OAuth redirects
 // HOW: Encode return URL in state parameter or use sessionStorage

--- a/pages/docs/security/best-practices.js
+++ b/pages/docs/security/best-practices.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: Security best practices documentation for OAuth 2.0 SSO integration
 // WHY: Developers need comprehensive security guidance to avoid vulnerabilities

--- a/pages/docs/security/cors.js
+++ b/pages/docs/security/cors.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: CORS configuration documentation for SSO OAuth 2.0 integration
 // WHY: Developers need to understand CORS setup for cross-origin SSO requests

--- a/pages/docs/security/permissions.js
+++ b/pages/docs/security/permissions.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel, DocsPageShell, PublicShell, SimpleDataTable } from '@doneisbetter/gds-core/server'
+import { AccentPanel, DocsPageShell, PublicShell, SimpleDataTable } from '@sovereignsquad/gds-core/server'
 import { createDocsVersionMeta, getDocsShellProps } from '../../../lib/docs-shell-config'
 // WHAT: App permissions system documentation for OAuth 2.0 SSO integration
 // WHY: Developers need to understand app-level permissions and roles

--- a/pages/docs/session-management.js
+++ b/pages/docs/session-management.js
@@ -8,7 +8,7 @@ import {
   Box,
   Anchor,
 } from '@mantine/core';
-import { AccentPanel } from '@doneisbetter/gds-core/server'
+import { AccentPanel } from '@sovereignsquad/gds-core/server'
 // WHAT: OAuth 2.0 token lifecycle and session management documentation
 // WHY: Developers need to understand token types, expiry, and refresh mechanisms
 // HOW: Explains access tokens, refresh tokens, ID tokens, and session validation

--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -11,7 +11,7 @@ import {
   TextInput,
   ThemeIcon,
 } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertCircle, IconCheck, IconKey, IconMail } from '@tabler/icons-react'
 
 export default function ForgotPassword() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,7 +20,7 @@ import {
   FeatureBand,
   PublicBrandFooter,
   PublicShell,
-} from '@doneisbetter/gds-core/server'
+} from '@sovereignsquad/gds-core/server'
 import {
   IconApps,
   IconArrowRight,

--- a/pages/login.js
+++ b/pages/login.js
@@ -32,7 +32,7 @@ import {
   IconLink,
   IconLock,
 } from '@tabler/icons-react'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 
 // WHAT: Make page server-rendered to ensure query params are available immediately
 // WHY: useRouter().query can be empty on first render, causing OAuth params to be lost

--- a/pages/logout.js
+++ b/pages/logout.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { Box, Loader, Stack, Text, ThemeIcon } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconLogout } from '@tabler/icons-react'
 
 export default function LogoutPage() {

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Anchor, Box, Group, List, Stack, Text, Title } from '@mantine/core'
-import { ArticleShell, PublicBrandFooter, PublicShell } from '@doneisbetter/gds-core/server'
+import { ArticleShell, PublicBrandFooter, PublicShell } from '@sovereignsquad/gds-core/server'
 
 export default function PrivacyPage() {
   return (

--- a/pages/register.js
+++ b/pages/register.js
@@ -20,7 +20,7 @@ import {
   Text,
   TextInput,
 } from '@mantine/core'
-import { AuthShell } from '@doneisbetter/gds-core/server'
+import { AuthShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertCircle, IconAt, IconLock, IconUser, IconUserPlus } from '@tabler/icons-react'
 
 export async function getServerSideProps(context) {

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Anchor, Box, Group, List, Stack, Text, Title } from '@mantine/core'
-import { ArticleShell, PublicBrandFooter, PublicShell } from '@doneisbetter/gds-core/server'
+import { ArticleShell, PublicBrandFooter, PublicShell } from '@sovereignsquad/gds-core/server'
 
 export default function TermsPage() {
   return (

--- a/pages/test-fetch.js
+++ b/pages/test-fetch.js
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
 import { Alert, Anchor, Box, Button, Code, Group, Stack, Text } from '@mantine/core'
-import { ArticleShell, PublicBrandFooter, PublicShell } from '@doneisbetter/gds-core/server'
+import { ArticleShell, PublicBrandFooter, PublicShell } from '@sovereignsquad/gds-core/server'
 import { IconAlertCircle, IconBug, IconCheck } from '@tabler/icons-react'
 
 export default function TestFetch() {


### PR DESCRIPTION
## Summary

- The design-system dependency was pinned to `@doneisbetter/gds-*@3.0.0`, a legacy npm-registry mirror. The actual upstream project (`sovereignsquad/general-design-system`) has moved on to `@sovereignsquad/gds-*@4.1.3`, published on GitHub Packages — the `@doneisbetter` mirror is no longer the current release line.
- Rescoped and bumped all `gds-*` runtime/dev dependencies to `4.1.3` in `package.json`, added GitHub Packages registry routing for the `@sovereignsquad` scope in `.npmrc` (auth token sourced from an environment variable, never a literal secret), and added `@mantine/dates@9.2.1` as an explicit direct dependency to resolve a peer-dependency conflict the upgrade introduced.
- Rewrote the import specifier in all 52 source files that consumed a `@doneisbetter/gds-*` package. This is a scope rename only — no component usage, contract, or visual behavior changed. `lib/theme/mantineTheme.js` continues to use `extendGdsTheme`, confirmed still functional upstream (soft-deprecated, not removed); migrating it to `createPublicBrandTheme` is left for a follow-up.
- Updated `gds-adoption.json` and `docs/DESIGN_SYSTEM.md` to the new scope, version, and alignment date. Both approved exceptions (OAuth provider buttons, docs editorial shell) are unchanged by this migration.
- Bumped service version to `5.31.2` (patch: dependency migration only, no behavior change) and synced `docs/CHANGELOG.md`, `docs/RELEASE_NOTES.md`, `docs/ROADMAP.md`, and all version-stamped docs.

Closes #62.

## Known operational gap — CI will fail on `npm ci` until a secret is added

`.github/workflows/repo-guardrails.yml` runs `npm ci` on every push/PR. The default `GITHUB_TOKEN` GitHub Actions provides is scoped to this repository only and cannot authenticate against `@sovereignsquad/gds-*` packages published under a different owner on `npm.pkg.github.com`. This PR wires the install step to read a `GDS_PACKAGES_TOKEN` secret instead, but that secret does not exist yet — **someone with repository admin access needs to add it** (a classic PAT with the `read:packages` scope and read access to the `sovereignsquad` org's packages) under Settings → Secrets and Variables → Actions. Until then, CI on this PR is expected to fail at the install step, not because of a defect in this change.

The same gap applies to the Vercel deployment build for this PR (also runs `npm ci`/`npm install` against the same registry) — it will fail for the identical reason until Vercel's project environment has an equivalent `read:packages`-scoped credential available at build time.

## Testing

- `npm run verify` (lint, type-check, test, build, guard:repo, check:docs) — clean
- `npm run gds:validate-manifest`, `npm run gds:check`, `npm run lint:gds` — all clean
- Confirmed no `@doneisbetter/gds*` references remain anywhere in tracked source or docs
- Confirmed no literal secret values were committed (`.npmrc` and `package-lock.json` both checked)
- Pre-existing `npm audit` findings (10 vulnerabilities, 8 high) individually cross-referenced against this diff — none are newly introduced by this migration; left untouched as out of scope